### PR TITLE
First draft api

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,8 @@ Checks: >
    -performance-no-int-to-ptr,
    -*-non-private-member-variables-in-classes,
    -*-magic-numbers,
-   -concurrency-*
+   -concurrency-*,
+   -clang-analyzer-security*
 
 CheckOptions:
    - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: true }

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ There are still improvements to be made to this library as time allows for packa
 #include <stddef.h>
 #include <stdio.h>
 
-/* Read-only view of string data. Prefer the provided functions for
-   string manipulations rather than using the provided fields. This
-   interface is modeled after std::string_view in C++ with elements
-   of C mixed in. The str_view type is 16 bytes meaning it is cheap
-   to copy and flexible to work with in the provided functions. No
-   functions accept str_view by reference, except for swap. */
+/* A str_view is a read-only view of string data in C. It is modeled after
+   the C++ std::string_view. It consists of a pointer to const char data
+   and a size_t field. Therefore, the exact size of this type may be platform
+   dependent but it is small enough that one should prefer to use the provided
+   functions when manupulating views. Try to avoid accessing struct fields.
+   A str_view is a cheap, copyable type in all functions but swap. */
 typedef struct
 {
     const char *s;
@@ -29,46 +29,41 @@ typedef struct
 } str_view;
 
 /* Standard three way comparison type in C. See the comparison
-   functions for how to interpret the sv comparison results. */
+   functions for how to interpret the comparison results. ERR
+   is returned if bad input is provided to any comparison. */
 typedef enum
 {
     LES = -1,
     EQL = 0,
     GRT = 1,
+    ERR,
 } sv_threeway_cmp;
 
 /*==========================  Construction  ================================*/
 
-/* A macro provided to make str_view constants less error prone at
-   compile time. For example, if it is desirable to construct a str_view
-   constant the following will obtain the length field for the user.
-   Simply copy and paste the same string twice for best results.
+/* A macro provided to obtain the length of string literals. Best used with
+   the next macro but perhaps has uses on its own.
 
       static const str_view prefix = {.s = "test_", .sz = SVLEN("test_")};
-      int main()
-      {
-         ...
-      }
 
    At runtime, prefer the provided functions for all other str_view needs. */
 #define SVLEN(str) ((sizeof((str)) / sizeof((str)[0])) - sizeof((str)[0]))
 
-/* A macro to further reduce the chance for errors in repeating oneself
-   when constructing inline or const str_views. The input must be a string
+/* A macro to reduce the chance for errors in repeating oneself when
+   constructing inline or const str_views. The input must be a string
    literal. For example, the above example becomes:
 
       static const str_view prefix = SV("test_");
 
-   But more importantly this allows for inline constructors that are
-   easier to read than struct declarations and don't risk mistakes in
-   counting characters. For example:
+   One can even use this in code when string literals are used rather than
+   saved constants to avoid errors in str_view constructions.
 
        for (str_view cur = sv_begin_tok(ref, SV(" "));
             !sv_end_tok(ref_view, cur);
             cur = sv_next_tok(ref_view, cur, SV(" "))
        {}
 
-   However saving the delimiter in a constant may be more convenient. */
+   However saving the str_view in a constant may be more convenient. */
 #define SV(str) ((str_view){(str), SVLEN((str))})
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
@@ -98,7 +93,14 @@ str_view sv_n(const char *, size_t n);
    This is similar to the tokenizing function in the iterator section. */
 str_view sv_delim(const char *, const char *delim);
 
-/* A sentinel empty string. Safely dereferenced to view a null terminator. */
+/* Creates the substring from position pos for count length. The count is
+   the minimum value between count and (str_view.sz - pos). The process
+   will exit if position is greater than str_view size. */
+str_view sv_substr(str_view, size_t pos, size_t count);
+
+/* A sentinel empty string. Safely dereferenced to view a null terminator.
+   This may be returned from various functions when bad input is given
+   such as NULL as the underlying str_view string pointer. */
 const char *sv_null(void);
 
 /* The end of a str_view guaranted to be greater than or equal to size.
@@ -113,13 +115,14 @@ size_t sv_npos(str_view);
    found. See sv_svsv or sv_rsvsv as an example. */
 bool sv_empty(str_view);
 
-/* Returns the size of the string view O(1). */
+/* Returns the length of the str_view in O(1) time. */
 size_t sv_len(str_view);
 
 /* Returns the bytes of str_view including null terminator. Note that
    string views may not actually be null terminated but the position at
-   str_view[str_view.sz] is interpreted as the null terminator. */
-size_t sv_svbytes(str_view);
+   str_view[str_view.sz] is interpreted as the null terminator and thus
+   counts towards the byte count. */
+size_t sv_bytes(str_view);
 
 /* Returns the size of the null terminated string O(n) */
 size_t sv_strlen(const char *);
@@ -142,7 +145,7 @@ str_view sv_copy(const char *src_str, size_t str_sz);
 size_t sv_fill(char *dest_buf, size_t dest_sz, str_view src);
 
 /* Returns a str_view of the entirety of the underlying string, starting
-   at the current views pointer position. This guarantees that the str_view
+   at the current view pointer position. This guarantees that the str_view
    returned ends at the null terminator of the underlying string as all
    strings used with str_views are assumed to be null terminated. It is
    undefined behavior to provide non null terminated strings to any
@@ -155,14 +158,20 @@ str_view sv_extend(str_view src);
    between two string views.
    lhs LES( -1  ) rhs (lhs is less than rhs)
    lhs EQL(  0  ) rhs (lhs is equal to rhs)
-   lhs GRT(  1  ) rhs (lhs is greater than rhs)*/
-sv_threeway_cmp sv_svcmp(str_view, str_view);
+   lhs GRT(  1  ) rhs (lhs is greater than rhs).
+   Comparison is bounded by the shorter str_view length. ERR is
+   returned if bad input is provided such as a str_view with a
+   NULL pointer field. */
+sv_threeway_cmp sv_cmp(str_view, str_view);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and a c-string.
    str_view LES( -1  ) rhs (str_view is less than str)
    str_view EQL(  0  ) rhs (str_view is equal to str)
-   str_view GRT(  1  ) rhs (str_view is greater than str)*/
+   str_view GRT(  1  ) rhs (str_view is greater than str)
+   Comparison is bounded by the shorter str_view length. ERR is
+   returned if bad input is provided such as a str_view with a
+   NULL pointer field. */
 sv_threeway_cmp sv_strcmp(str_view, const char *str);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
@@ -170,7 +179,10 @@ sv_threeway_cmp sv_strcmp(str_view, const char *str);
    or stops at the null terminator if that is encountered first.
    str_view LES( -1  ) rhs (str_view is less than str)
    str_view EQL(  0  ) rhs (str_view is equal to str)
-   str_view GRT(  1  ) rhs (str_view is greater than str)*/
+   str_view GRT(  1  ) rhs (str_view is greater than str)
+   Comparison is bounded by the shorter str_view length. ERR is
+   returned if bad input is provided such as a str_view with a
+   NULL pointer field. */
 sv_threeway_cmp sv_strncmp(str_view, const char *str, size_t n);
 
 /* Returns the minimum between the string size vs n bytes. */
@@ -178,17 +190,79 @@ size_t sv_minlen(const char *, size_t n);
 
 /*============================  Iteration  ==================================*/
 
-/* The characer in the string at position i with bounds checking.
-   The program will exit if an out of bounds error occurs. */
-char sv_at(str_view, size_t i);
+/* For the forward and reverse tokenization use the idiomatic for loop
+   to acheive the desired tokenization.
 
-/* The character at the first position of str_view. An empty
-   str_view or NULL pointer is valid and will return '\0'. */
-char sv_front(str_view);
+      for (str_view tok = sv_begin_tok(src, delim);
+           !sv_end_tok(src, tok),
+           tok = sv_next_tok(src, tok, delim))
+      {}
 
-/* The character at the last position of str_view. An empty
-   str_view or NULL pointer is valid and will return '\0'. */
-char sv_back(str_view);
+      for (str_view tok = sv_rbegin_tok(src, delim);
+           !sv_rend_tok(src, tok),
+           tok = sv_rnext_tok(src, tok, delim))
+      {}
+
+   Other patterns are possible but this is recommended for tokenization.
+   The same applies to character iteration.
+
+      for (const char *i = sv_begin(src); i != sv_end(src); i = sv_next(i))
+      {}
+
+      for (const char *i = sv_rbegin(src); i != sv_rend(src); i = sv_rnext(i))
+      {}
+
+   For character iteration, it is undefined behavior to change the str_view
+   being iterated through before the loop terminates. */
+
+/* Finds the first tokenized position in the string view given any length
+   delim str_view. Skips leading delimeters in construction. If the
+   str_view to be searched stores NULL than the sv_null() is returned. If
+   delim stores NULL, that is interpreted as a search for the null terminating
+   character or empty string and the size zero substring at the final position
+   in the str_view is returned wich may or may not be the null termiator. If no
+   delim is found the entire str_view is returned. */
+str_view sv_begin_tok(str_view src, str_view delim);
+
+/* Returns true if no further tokes are found and position is at the end
+   position, meaning a call to sv_next_tok has yielded a size 0 str_view
+   that points at the end of the src str_view which may or may not be null
+   terminated. */
+bool sv_end_tok(str_view src, str_view tok);
+
+/* Advances to the next token in the remaining view seperated by the delim.
+   Repeating delimter patterns will be skipped until the next token or end
+   of string is found. If str_view stores NULL the sv_null() placeholder
+   is returned. If delim stores NULL the end position of the str_view
+   is returned which may or may not be the null terminator. The tok is
+   bounded by the length of the view between two delimeters or the length
+   from a delimeter to the end of src, whichever comes first. */
+str_view sv_next_tok(str_view src, str_view tok, str_view delim);
+
+/* Obtains the last token in a string in preparation for reverse tokenized
+   iteration. Any delimeters that end the string are skipped, as in the
+   forward version. If src is NULL sv_null is returned. If delim is null
+   the entire src view is returned. Though the str_view is tokenized in
+   reverse, the token view will start at the first character and be the
+   length of the token found. */
+str_view sv_rbegin_tok(str_view src, str_view delim);
+
+/* Given the current str_view being iterated through and the current token
+   in the iteration returns true if the ending state of a reverse tokenization
+   has been reached, false otherwise. */
+bool sv_rend_tok(str_view src, str_view tok);
+
+/* Advances the token in src to the next token between two delimeters provided
+   by delim. Repeating delimiters are skipped until the next token is found.
+   If no further tokens can be found an empty str_view is returned with its
+   pointer set to the start of the src string being iterated through. Note
+   that a multicharacter delimiter may yeild different tokens in reverse
+   than in the forward direction when partial matches occur and some portion
+   of the delimeter is in a token. This is because the string is now being
+   parsed from right to left. However, the token returned starts at the first
+   character and is read from left to right between two delimeters as is
+   in the forward tokenization.  */
+str_view sv_rnext_tok(str_view src, str_view tok, str_view delim);
 
 /* Returns a read only pointer to the beginning of the string view,
    the first valid character in the view. If the view stores NULL,
@@ -227,61 +301,20 @@ const char *sv_rnext(const char *);
    str_view then sv_null() is returned. */
 const char *sv_pos(str_view, size_t i);
 
-/* Finds the first tokenized position in the string view given the any
-   sized delimeter str_view. This means that if the string begins
-   with a delimeter, that delimeter is skipped until a string token
-   is found. For example:
+/* The characer in the string at position i with bounds checking.
+   If i is greater than or equal to the size of str_view the null
+   terminator character is returned. */
+char sv_at(str_view, size_t i);
 
-     const char *const str = "  Hello world!";
-     sv_print(sv_delim(str, " "));
-     <<< "Hello"
+/* The character at the first position of str_view. An empty
+   str_view or NULL pointer is valid and will return '\0'. */
+char sv_front(str_view);
 
-   This is similar to the sv_delim constructor. If the str_view
-   to be searched stores NULL than the sv_null() is returned. If
-   delim stores NULL, that is interpreted as a search for the null
-   terminating character or empty string and the size zero substring
-   at the final position in the str_view is returned wich may or
-   may not be the null termiator. */
-str_view sv_begin_tok(str_view src, str_view delim);
-
-/* Returns true if no further tokes are found and position is at the end
-   position, meaning a call to sv_next_tok has yielded a size 0 str_view */
-bool sv_end_tok(str_view src, str_view tok);
-
-/* Advances to the next token in the remaining view seperated by the delim.
-   Repeating delimter patterns will be skipped until the next token or end
-   of string is found. If str_view stores NULL the sv_null() placeholder
-   is returned. If delim stores NULL the end position of the str_view
-   is returned which may or may not be the null terminator. */
-str_view sv_next_tok(str_view src, str_view tok, str_view delim);
-
-/* Obtains the last token in a string in preparation for reverse tokenized
-   iteration. Any delimeters that start the string are skipped, as in the
-   forward version. If src is null sv_null is returned. If delim is null
-   the entire src view is returned. */
-str_view sv_rbegin_tok(str_view src, str_view delim);
-
-/* Given the current str_view being iterated through and the current token
-   in the iteration returns true if the ending state of a reverse tokenization
-   has been reached, false otherwise. */
-bool sv_rend_tok(str_view src, str_view tok);
-
-/* Advances the token in src to the next token between two delimeters provided
-   by delim. Repeating delimiters are skipped until the next token is found.
-   If no further tokens can be found an empty str_view is returned with its
-   pointer set to the start of the src string being iterated through. Note
-   that a multicharacter delimiter may yeild different tokens in reverse
-   than in the forward direction when partial matches occur and some portion
-   of the delimeter is in a token. This is because the string is now being
-   read from right to left. */
-str_view sv_rnext_tok(str_view src, str_view tok, str_view delim);
+/* The character at the last position of str_view. An empty
+   str_view or NULL pointer is valid and will return '\0'. */
+char sv_back(str_view);
 
 /*============================  Searching  =================================*/
-
-/* Creates the substring from position pos for count length. The count is
-   the minimum value between count and (str_view.sz - pos). The process
-   will exit if position is greater than str_view size. */
-str_view sv_substr(str_view, size_t pos, size_t count);
 
 /* Searches for needle in hay starting from pos. If the needle
    is larger than the hay, or position is greater than hay length,
@@ -304,7 +337,7 @@ bool sv_contains(str_view hay, str_view needle);
    hay length position is returned. This may or may not be null
    terminated at that position. If needle is greater than
    hay length an empty view at the end of hay is returned. If
-   hay is NULL, sv_null is returned. */
+   hay is NULL, sv_null is returned (modeled after strstr). */
 str_view sv_svsv(str_view hay, str_view needle);
 
 /* Returns a view of the needle found in hay at the last found
@@ -312,7 +345,7 @@ str_view sv_svsv(str_view hay, str_view needle);
    hay length position is returned. This may or may not be null
    terminated at that position. If needle is greater than
    hay length an empty view at hay size is returned. If hay is
-   NULL, sv_null is returned. */
+   NULL, sv_null is returned (modeled after strstr). */
 str_view sv_rsvsv(str_view hay, str_view needle);
 
 /* Returns true if a prefix shorter than or equal in length to
@@ -357,7 +390,9 @@ size_t sv_find_last_of(str_view hay, str_view set);
    in the str_view. An empty hay will return 0. */
 size_t sv_find_last_not_of(str_view hay, str_view set);
 
-/* Writes all characters in str_view to stdout. */
+/*============================  Printing  ==================================*/
+
+/* Writes all characters in str_view to specified file such as stdout. */
 void sv_print(FILE *, str_view);
 
 #endif /* STR_VIEW */

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -154,9 +154,9 @@ sv_fill(char *dest_buf, size_t dest_sz, const str_view src)
 }
 
 bool
-sv_empty(const str_view s)
+sv_empty(const str_view sv)
 {
-    return !s.s || s.sz == 0;
+    return !sv.s || sv.sz == 0;
 }
 
 size_t
@@ -224,70 +224,70 @@ sv_swap(str_view *a, str_view *b)
 }
 
 sv_threeway_cmp
-sv_cmp(str_view sv1, str_view sv2)
+sv_cmp(str_view lhs, str_view rhs)
 {
-    if (!sv1.s || !sv2.s)
+    if (!lhs.s || !rhs.s)
     {
         return ERR;
     }
-    const size_t sz = sv_min(sv1.sz, sv2.sz);
+    const size_t sz = sv_min(lhs.sz, rhs.sz);
     size_t i = 0;
-    for (; i < sz && sv1.s[i] == sv2.s[i]; ++i)
+    for (; i < sz && lhs.s[i] == rhs.s[i]; ++i)
     {}
-    if (i == sv1.sz && i == sv2.sz)
+    if (i == lhs.sz && i == rhs.sz)
     {
         return EQL;
     }
-    if (i < sv1.sz && i < sv2.sz)
+    if (i < lhs.sz && i < rhs.sz)
     {
-        return (uint8_t)sv1.s[i] < (uint8_t)sv2.s[i] ? LES : GRT;
+        return (uint8_t)lhs.s[i] < (uint8_t)rhs.s[i] ? LES : GRT;
     }
-    return (i < sv1.sz) ? GRT : LES;
+    return (i < lhs.sz) ? GRT : LES;
 }
 
 sv_threeway_cmp
-sv_strcmp(str_view sv, const char *str)
+sv_strcmp(str_view lhs, const char *rhs)
 {
-    if (!sv.s || !str)
+    if (!lhs.s || !rhs)
     {
         return ERR;
     }
-    const size_t sz = sv.sz;
+    const size_t sz = lhs.sz;
     size_t i = 0;
-    for (; i < sz && str[i] != '\0' && sv.s[i] == str[i]; ++i)
+    for (; i < sz && rhs[i] != '\0' && lhs.s[i] == rhs[i]; ++i)
     {}
-    if (i == sv.sz && str[i] == '\0')
+    if (i == lhs.sz && rhs[i] == '\0')
     {
         return EQL;
     }
-    if (i < sv.sz && str[i] != '\0')
+    if (i < lhs.sz && rhs[i] != '\0')
     {
-        return (uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT;
+        return (uint8_t)lhs.s[i] < (uint8_t)rhs[i] ? LES : GRT;
     }
-    return (i < sv.sz) ? GRT : LES;
+    return (i < lhs.sz) ? GRT : LES;
 }
 
 sv_threeway_cmp
-sv_strncmp(str_view sv, const char *str, const size_t n)
+sv_strncmp(str_view lhs, const char *rhs, const size_t n)
 {
-    if (!sv.s || !str)
+    if (!lhs.s || !rhs)
     {
         return ERR;
     }
-    const size_t sz = sv_min(sv.sz, n);
+    const size_t sz = sv_min(lhs.sz, n);
     size_t i = 0;
-    for (; i < sz && str[i] != '\0' && sv.s[i] == str[i]; ++i)
+    for (; i < sz && rhs[i] != '\0' && lhs.s[i] == rhs[i]; ++i)
     {}
-    if (i == sv.sz && sz == n)
+    if (i == lhs.sz && sz == n)
     {
         return EQL;
     }
     /* strncmp compares the first at most n bytes inclusive */
-    if (i < sv.sz && sz <= n)
+    if (i < lhs.sz && sz <= n)
     {
-        return (uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT;
+        return (uint8_t)lhs.s[i] < (uint8_t)rhs[i] ? LES : GRT;
     }
-    return (i < sv.sz) ? GRT : LES;
+    return (i < lhs.sz) ? GRT : LES;
 }
 
 char
@@ -321,13 +321,13 @@ sv_begin(const str_view sv)
 }
 
 const char *
-sv_end(const str_view src)
+sv_end(const str_view sv)
 {
-    if (!src.s || src.s == nil.s)
+    if (!sv.s || sv.s == nil.s)
     {
         return nil.s;
     }
-    return src.s + src.sz;
+    return sv.s + sv.sz;
 }
 
 const char *
@@ -511,17 +511,17 @@ sv_rend_tok(const str_view src, const str_view tok)
 }
 
 str_view
-sv_extend(str_view src)
+sv_extend(str_view sv)
 {
-    if (!src.s)
+    if (!sv.s)
     {
         return nil;
     }
-    const char *i = src.s;
+    const char *i = sv.s;
     while (*i++)
     {}
-    src.sz = i - src.s - 1;
-    return src;
+    sv.sz = i - sv.s - 1;
+    return sv;
 }
 
 bool

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -10,16 +10,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-
-#define QUIT(format, ...)                                                      \
-    do                                                                         \
-    {                                                                          \
-        (void)fprintf(stderr, (format)__VA_OPT__(, ) __VA_ARGS__);             \
-        (void)fprintf(stderr, "File: %s, Line: %d, Function: %s\n", __FILE__,  \
-                      __LINE__, __func__);                                     \
-        exit(1);                                                               \
-    } while (0)
+#include <string.h>
 
 /* ========================   Type Definitions   =========================== */
 
@@ -74,12 +65,9 @@ static size_t sv_threebyte_strnstrn(const unsigned char *, size_t,
                                     const unsigned char *);
 static size_t sv_fourbyte_strnstrn(const unsigned char *, size_t,
                                    const unsigned char *);
-static size_t sv_lenstr(const char *);
-static size_t sv_nlen(const char *, size_t);
 static size_t sv_strcspn(const char *, size_t, const char *, size_t);
 static size_t sv_strspn(const char *, size_t, const char *, size_t);
 static size_t sv_strnstrn(const char *, ssize_t, const char *, ssize_t);
-static void *sv_memmove(void *, const void *, size_t);
 static size_t sv_strnchr(const char *, char, size_t);
 static size_t sv_rstrnchr(const char *, char, size_t);
 static size_t sv_rstrnstrn(const char *, ssize_t, const char *, ssize_t);
@@ -109,7 +97,7 @@ sv_n(const char *const str, size_t n)
     {
         return nil;
     }
-    return (str_view){.s = str, .sz = sv_nlen(str, n)};
+    return (str_view){.s = str, .sz = strnlen(str, n)};
 }
 
 str_view
@@ -159,10 +147,10 @@ sv_fill(char *dest_buf, size_t dest_sz, const str_view src)
     {
         return 0;
     }
-    const size_t paste = sv_min(dest_sz, sv_svbytes(src));
-    sv_memmove(dest_buf, src.s, paste);
-    dest_buf[paste - 1] = '\0';
-    return paste;
+    const size_t bytes = sv_min(dest_sz, sv_bytes(src));
+    memmove(dest_buf, src.s, bytes);
+    dest_buf[bytes - 1] = '\0';
+    return bytes;
 }
 
 bool
@@ -178,7 +166,7 @@ sv_len(str_view sv)
 }
 
 size_t
-sv_svbytes(str_view sv)
+sv_bytes(str_view sv)
 {
     return sv.sz + 1;
 }
@@ -186,7 +174,7 @@ sv_svbytes(str_view sv)
 size_t
 sv_strlen(const char *const str)
 {
-    return sv_lenstr(str);
+    return strlen(str);
 }
 
 size_t
@@ -196,13 +184,13 @@ sv_strbytes(const char *const str)
     {
         return 0;
     }
-    return sv_lenstr(str) + 1;
+    return strlen(str) + 1;
 }
 
 size_t
 sv_minlen(const char *const str, size_t n)
 {
-    return sv_nlen(str, n);
+    return strnlen(str, n);
 }
 
 char
@@ -210,7 +198,7 @@ sv_at(str_view sv, size_t i)
 {
     if (i >= sv.sz)
     {
-        QUIT("str_view index out of range. size=%zu, index=%zu\n", sv.sz, i);
+        return *nil.s;
     }
     return sv.s[i];
 }
@@ -235,12 +223,12 @@ sv_swap(str_view *a, str_view *b)
     a->sz = tmp_b.sz;
 }
 
-int
-sv_svcmp(str_view sv1, str_view sv2)
+sv_threeway_cmp
+sv_cmp(str_view sv1, str_view sv2)
 {
     if (!sv1.s || !sv2.s)
     {
-        QUIT("sv_svcmp cannot compare NULL.\n");
+        return ERR;
     }
     const size_t sz = sv_min(sv1.sz, sv2.sz);
     size_t i = 0;
@@ -252,17 +240,17 @@ sv_svcmp(str_view sv1, str_view sv2)
     }
     if (i < sv1.sz && i < sv2.sz)
     {
-        return ((uint8_t)sv1.s[i] < (uint8_t)sv2.s[i] ? LES : GRT);
+        return (uint8_t)sv1.s[i] < (uint8_t)sv2.s[i] ? LES : GRT;
     }
     return (i < sv1.sz) ? GRT : LES;
 }
 
-int
+sv_threeway_cmp
 sv_strcmp(str_view sv, const char *str)
 {
     if (!sv.s || !str)
     {
-        QUIT("sv_strcmp cannot compare NULL.\n");
+        return ERR;
     }
     const size_t sz = sv.sz;
     size_t i = 0;
@@ -274,17 +262,17 @@ sv_strcmp(str_view sv, const char *str)
     }
     if (i < sv.sz && str[i] != '\0')
     {
-        return ((uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT);
+        return (uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT;
     }
     return (i < sv.sz) ? GRT : LES;
 }
 
-int
+sv_threeway_cmp
 sv_strncmp(str_view sv, const char *str, const size_t n)
 {
     if (!sv.s || !str)
     {
-        QUIT("sv_strncmp cannot compare NULL.\n");
+        return ERR;
     }
     const size_t sz = sv_min(sv.sz, n);
     size_t i = 0;
@@ -297,7 +285,7 @@ sv_strncmp(str_view sv, const char *str, const size_t n)
     /* strncmp compares the first at most n bytes inclusive */
     if (i < sv.sz && sz <= n)
     {
-        return ((uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT);
+        return (uint8_t)sv.s[i] < (uint8_t)str[i] ? LES : GRT;
     }
     return (i < sv.sz) ? GRT : LES;
 }
@@ -423,7 +411,7 @@ sv_begin_tok(str_view src, str_view delim)
         return (str_view){.s = src.s, .sz = 0};
     }
     src.sz -= sv_not;
-    return sv_substr(src, 0, sv_find(src, 0, delim));
+    return (str_view){.s = src.s, .sz = sv_find(src, 0, delim)};
 }
 
 bool
@@ -450,6 +438,8 @@ sv_next_tok(const str_view src, str_view tok, str_view delim)
     }
     next.s += delim.sz;
     next.sz = src.sz - (next.s - src.s);
+    /* There is a cheap easy way to skip repeating delimiters before the
+       next search that should be faster than string comparison. */
     const size_t after_delim = sv_after_find(next, delim);
     next.s += after_delim;
     next.sz -= after_delim;
@@ -496,6 +486,9 @@ sv_rnext_tok(const str_view src, str_view tok, str_view delim)
         return (str_view){.s = src.s, .sz = 0};
     }
     const str_view shorter = {.s = src.s, .sz = (tok.s - delim.sz) - src.s};
+    /* Same as in the forward version, this method is a quick way to skip
+       any number of repeating delimiters before starting the next search
+       for a delimiter before a token. */
     const size_t before_delim = sv_before_rfind(shorter, delim);
     if (before_delim == shorter.sz)
     {
@@ -538,7 +531,7 @@ sv_starts_with(str_view sv, str_view prefix)
     {
         return false;
     }
-    return sv_svcmp(sv_substr(sv, 0, prefix.sz), prefix) == EQL;
+    return sv_cmp(sv_substr(sv, 0, prefix.sz), prefix) == EQL;
 }
 
 str_view
@@ -555,7 +548,7 @@ sv_ends_with(str_view sv, str_view suffix)
     {
         return false;
     }
-    return sv_svcmp(sv_substr(sv, sv.sz - suffix.sz, suffix.sz), suffix) == EQL;
+    return sv_cmp(sv_substr(sv, sv.sz - suffix.sz, suffix.sz), suffix) == EQL;
 }
 
 str_view
@@ -573,7 +566,7 @@ sv_substr(str_view sv, size_t pos, size_t count)
 {
     if (pos > sv.sz)
     {
-        QUIT("str_view index out of range. pos=%zu size=%zu", pos, sv.sz);
+        return (str_view){.s = sv.s + sv.sz, .sz = 0};
     }
     return (str_view){.s = sv.s + pos, .sz = sv_min(count, sv.sz - pos)};
 }
@@ -804,41 +797,11 @@ sv_char_cmp(char a, char b)
 /* ======================   Static Utilities    =========================== */
 
 /* This is section is modeled after the musl string.h library. However,
-   using str_view that may not be null terminated requires modifications.
-   Also it is important to not use string.h functionality which would force
-   the user to include string.h in addition to custom implementations here.
-   Save code bloat though compilers/linkers may help with that. */
+   using str_view that may not be null terminated requires modifications. */
 
 #define BITOP(a, b, op)                                                        \
     ((a)[(size_t)(b) / (8 * sizeof *(a))] op(size_t) 1                         \
      << ((size_t)(b) % (8 * sizeof *(a))))
-
-/* Modeled after musl
-   http://git.musl-libc.org/cgit/musl/tree/src/string/strlen.c */
-static size_t
-sv_lenstr(const char *const str)
-{
-    if (!str)
-    {
-        return 0;
-    }
-    const char *i = str;
-    for (; *i; ++i)
-    {}
-    return i - str;
-}
-
-/* Modeled after musl
-   http://git.musl-libc.org/cgit/musl/tree/src/string/memcmp.c */
-static int
-sv_memcmp(const void *const vl, const void *const vr, size_t n)
-{
-    const unsigned char *l = vl;
-    const unsigned char *r = vr;
-    for (; n && *l == *r; n--, l++, r++)
-    {}
-    return n ? *l - *r : 0;
-}
 
 /* This is dangerous. Do not use this under normal circumstances.
    This is an internal helper for the backwards two way string
@@ -854,121 +817,6 @@ sv_rmemcmp(const void *const vl, const void *const vr, size_t n)
     for (; n && *l == *r; n--, l--, r--)
     {}
     return n ? *l - *r : 0;
-}
-
-/* Modeled after musl
-   http://git.musl-libc.org/cgit/musl/tree/src/string/memcpy.c */
-static void *
-sv_memcpy(void *restrict dest, const void *const restrict src, size_t n)
-{
-    unsigned char *d = dest;
-    const unsigned char *s = src;
-    for (; n; n--)
-    {
-        *d++ = *s++;
-    }
-    return dest;
-}
-
-/* Modeled after musl
-   http://git.musl-libc.org/cgit/musl/tree/src/string/memmove.c */
-static void *
-sv_memmove(void *dest, const void *const src, size_t n)
-{
-    char *d = dest;
-    const char *s = src;
-    if (d == s)
-    {
-        return d;
-    }
-    if ((uintptr_t)s - (uintptr_t)d - n <= -2 * n)
-    {
-        return sv_memcpy(d, s, n);
-    }
-    if (d < s)
-    {
-        for (; n; n--)
-        {
-            *d++ = *s++;
-        }
-    }
-    else
-    {
-        while (n)
-        {
-            n--;
-            d[n] = s[n];
-        }
-    }
-    return dest;
-}
-
-/* Modeled after musl implementation
-   https://git.musl-libc.org/cgit/musl/tree/src/string/memset.c */
-static void *
-sv_memset(void *dest, int c, size_t n)
-{
-    if (!dest)
-    {
-        return NULL;
-    }
-    unsigned char *s = dest;
-    size_t k;
-    /* Fill head and tail with minimal branching. Each
-       conditional ensures that all the subsequently used
-       offsets are well-defined and in the dest region. */
-    if (!n)
-    {
-        return dest;
-    }
-    s[0] = c;
-    s[n - 1] = c;
-    if (n <= 2)
-    {
-        return dest;
-    }
-    s[1] = c;
-    s[2] = c;
-    s[n - 2] = c;
-    s[n - 3] = c;
-    if (n <= 6)
-    {
-        return dest;
-    }
-    s[3] = c;
-    s[n - 4] = c;
-    if (n <= 8)
-    {
-        return dest;
-    }
-    /* Advance pointer to align it at a 4-byte boundary,
-       and truncate n to a multiple of 4. The previous code
-       already took care of any head/tail that get cut off
-       by the alignment. */
-    k = -(uintptr_t)s & 3;
-    s += k;
-    n -= k;
-    n &= -4;
-    for (; n; n--, s++)
-    {
-        *s = c;
-    }
-    return dest;
-}
-
-/* Modeled after musl
-   http://git.musl-libc.org/cgit/musl/tree/src/string/strnlen.c */
-static size_t
-sv_nlen(const char *const str, size_t n)
-{
-    if (!str)
-    {
-        return 0;
-    }
-    const char *i = str;
-    for (; n && *i; n--, ++i)
-    {}
-    return i - str;
 }
 
 /* strspn is based on musl C-standard library implementation
@@ -992,7 +840,7 @@ sv_strcspn(const char *const str, size_t str_sz, const char *set, size_t set_sz)
             ;
         return a - str;
     }
-    sv_memset(byteset, 0, sizeof byteset);
+    memset(byteset, 0, sizeof byteset);
     for (size_t i = 0;
          i < set_sz && *set && BITOP(byteset, *(unsigned char *)set, |=);
          set++, ++i)
@@ -1154,7 +1002,7 @@ sv_two_way(const char *const hay, ssize_t hay_sz, const char *const needle,
         period_dist = r.period_dist;
     }
     /* Determine if memoization is available due to found border/overlap. */
-    if (sv_memcmp(needle, needle + period_dist, critical_pos + 1) == 0)
+    if (memcmp(needle, needle + period_dist, critical_pos + 1) == 0)
     {
         return sv_two_way_memoization((struct sv_two_way_pack){
             .hay = hay,
@@ -1289,6 +1137,8 @@ sv_maximal_suffix(const char *const needle, ssize_t needle_sz)
             last_rest = suff_pos + 1;
             rest = period = 1;
             break;
+        default:
+            break;
         }
     }
     return (struct sv_factorization){.start_critical_pos = suff_pos,
@@ -1329,6 +1179,8 @@ sv_maximal_suffix_rev(const char *const needle, ssize_t needle_sz)
             suff_pos = last_rest;
             last_rest = suff_pos + 1;
             rest = period = 1;
+            break;
+        default:
             break;
         }
     }
@@ -1526,6 +1378,8 @@ sv_rmaximal_suffix(const char *const needle, ssize_t needle_sz)
             last_rest = suff_pos + 1;
             rest = period = 1;
             break;
+        default:
+            break;
         }
     }
     return (struct sv_factorization){.start_critical_pos = suff_pos,
@@ -1564,6 +1418,8 @@ sv_rmaximal_suffix_rev(const char *const needle, ssize_t needle_sz)
             suff_pos = last_rest;
             last_rest = suff_pos + 1;
             rest = period = 1;
+            break;
+        default:
             break;
         }
     }

--- a/str_view/str_view.c
+++ b/str_view/str_view.c
@@ -123,15 +123,15 @@ sv_delim(const char *const str, const char *const delim)
 }
 
 void
-sv_print(FILE *f, str_view s)
+sv_print(FILE *f, str_view sv)
 {
-    if (!s.s || nil.s == s.s || 0 == s.sz || !f)
+    if (!sv.s || nil.s == sv.s || 0 == sv.sz || !f)
     {
         return;
     }
     /* printf does not output the null terminator in normal strings so
        as long as we output correct number of characters we do the same */
-    (void)fwrite(s.s, sizeof(char), s.sz, f);
+    (void)fwrite(sv.s, sizeof(char), sv.sz, f);
 }
 
 str_view

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -139,7 +139,7 @@ size_t sv_fill(char *dest_buf, size_t dest_sz, str_view src);
    strings used with str_views are assumed to be null terminated. It is
    undefined behavior to provide non null terminated strings to any
    str_view code. */
-str_view sv_extend(str_view src);
+str_view sv_extend(str_view);
 
 /*============================  Comparison  ================================*/
 
@@ -161,7 +161,7 @@ sv_threeway_cmp sv_cmp(str_view, str_view);
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-sv_threeway_cmp sv_strcmp(str_view, const char *str);
+sv_threeway_cmp sv_strcmp(str_view, const char *);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and the first n bytes (inclusive) of str
@@ -172,7 +172,7 @@ sv_threeway_cmp sv_strcmp(str_view, const char *str);
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-sv_threeway_cmp sv_strncmp(str_view, const char *str, size_t n);
+sv_threeway_cmp sv_strncmp(str_view, const char *, size_t n);
 
 /* Returns the minimum between the string size vs n bytes. */
 size_t sv_minlen(const char *, size_t n);

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -57,12 +57,12 @@ typedef enum
 
 /* Constructs and returns a string view from a NULL TERMINATED string.
    It is undefined to construct a str_view from a non terminated string. */
-str_view sv(const char *);
+str_view sv(const char *str);
 
 /* Constructs and returns a string view from a sequence of valid n bytes
    or string length, whichever comes first. The resulting str_view may
    or may not be null terminated at the index of its size. */
-str_view sv_n(const char *, size_t n);
+str_view sv_n(const char *str, size_t n);
 
 /* Constructs and returns a string view from a NULL TERMINATED string
    broken on the first ocurrence of delimeter if found or null
@@ -80,12 +80,12 @@ str_view sv_n(const char *, size_t n);
      <<< ""
 
    This is similar to the tokenizing function in the iterator section. */
-str_view sv_delim(const char *, const char *delim);
+str_view sv_delim(const char *str, const char *delim);
 
 /* Creates the substring from position pos for count length. The count is
    the minimum value between count and (str_view.sz - pos). The process
    will exit if position is greater than str_view size. */
-str_view sv_substr(str_view, size_t pos, size_t count);
+str_view sv_substr(str_view sv, size_t pos, size_t count);
 
 /* A sentinel empty string. Safely dereferenced to view a null terminator.
    This may be returned from various functions when bad input is given
@@ -96,28 +96,28 @@ const char *sv_null(void);
    May be used for the idiomatic check for most string searching function
    return values when something is not found. If a size is returned from
    a searching function it is possible to check it against npos. */
-size_t sv_npos(str_view);
+size_t sv_npos(str_view sv);
 
 /* Returns true if the provided str_view is empty, false otherwise.
    This is a useful function to check for str_view searches that yeild
    an empty view at the end of a str_view when an element cannot be
    found. See sv_svsv or sv_rsvsv as an example. */
-bool sv_empty(str_view);
+bool sv_empty(str_view sv);
 
 /* Returns the length of the str_view in O(1) time. */
-size_t sv_len(str_view);
+size_t sv_len(str_view sv);
 
 /* Returns the bytes of str_view including null terminator. Note that
    string views may not actually be null terminated but the position at
    str_view[str_view.sz] is interpreted as the null terminator and thus
    counts towards the byte count. */
-size_t sv_bytes(str_view);
+size_t sv_bytes(str_view sv);
 
 /* Returns the size of the null terminated string O(n) */
-size_t sv_strlen(const char *);
+size_t sv_strlen(const char *str);
 
 /* Returns the bytes of the string pointer to, null terminator included. */
-size_t sv_strbytes(const char *);
+size_t sv_strbytes(const char *str);
 
 /* Swaps the contents of a and b. Becuase these are read only views
    only pointers and sizes are exchanged. */
@@ -139,7 +139,7 @@ size_t sv_fill(char *dest_buf, size_t dest_sz, str_view src);
    strings used with str_views are assumed to be null terminated. It is
    undefined behavior to provide non null terminated strings to any
    str_view code. */
-str_view sv_extend(str_view);
+str_view sv_extend(str_view sv);
 
 /*============================  Comparison  ================================*/
 
@@ -151,7 +151,7 @@ str_view sv_extend(str_view);
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-sv_threeway_cmp sv_cmp(str_view, str_view);
+sv_threeway_cmp sv_cmp(str_view lhs, str_view rhs);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and a c-string.
@@ -161,7 +161,7 @@ sv_threeway_cmp sv_cmp(str_view, str_view);
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-sv_threeway_cmp sv_strcmp(str_view, const char *);
+sv_threeway_cmp sv_strcmp(str_view lhs, const char *rhs);
 
 /* Returns the standard C threeway comparison between cmp(lhs, rhs)
    between a str_view and the first n bytes (inclusive) of str
@@ -172,10 +172,10 @@ sv_threeway_cmp sv_strcmp(str_view, const char *);
    Comparison is bounded by the shorter str_view length. ERR is
    returned if bad input is provided such as a str_view with a
    NULL pointer field. */
-sv_threeway_cmp sv_strncmp(str_view, const char *, size_t n);
+sv_threeway_cmp sv_strncmp(str_view lhs, const char *rhs, size_t n);
 
 /* Returns the minimum between the string size vs n bytes. */
-size_t sv_minlen(const char *, size_t n);
+size_t sv_minlen(const char *str, size_t n);
 
 /*============================  Iteration  ==================================*/
 
@@ -256,52 +256,52 @@ str_view sv_rnext_tok(str_view src, str_view tok, str_view delim);
 /* Returns a read only pointer to the beginning of the string view,
    the first valid character in the view. If the view stores NULL,
    the placeholder sv_null() is returned. */
-const char *sv_begin(str_view);
+const char *sv_begin(str_view sv);
 
 /* Returns a read only pointer to the end of the string view. This
    may or may not be a null terminated character depending on the
    view. If the view stores NULL, the placeholder sv_null() is returned. */
-const char *sv_end(str_view);
+const char *sv_end(str_view sv);
 
 /* Advances the pointer from its previous position. If NULL is provided
    sv_null() is returned. */
-const char *sv_next(const char *);
+const char *sv_next(const char *c);
 
 /* Returns the reverse iterator beginning, the last character of the
    current view. If the view is null sv_null() is returned. If the
    view is sized zero with a valid pointer that pointer in the
    view is returned. */
-const char *sv_rbegin(str_view);
+const char *sv_rbegin(str_view sv);
 
 /* The ending position of a reverse iteration. It is undefined
    behavior to access or use rend. It is undefined behavior to
    pass in any str_view not being iterated through as started
    with rbegin. */
-const char *sv_rend(str_view);
+const char *sv_rend(str_view sv);
 
 /* Advances the iterator to the next character in the str_view
    being iterated through in reverse. It is undefined behavior
    to change the str_view one is iterating through during
    iteration. If the char pointer is null, sv_null() is returned. */
-const char *sv_rnext(const char *);
+const char *sv_rnext(const char *c);
 
 /* Returns the character pointer at the minimum between the indicated
    position and the end of the string view. If NULL is stored by the
    str_view then sv_null() is returned. */
-const char *sv_pos(str_view, size_t i);
+const char *sv_pos(str_view sv, size_t i);
 
 /* The characer in the string at position i with bounds checking.
    If i is greater than or equal to the size of str_view the null
    terminator character is returned. */
-char sv_at(str_view, size_t i);
+char sv_at(str_view sv, size_t i);
 
 /* The character at the first position of str_view. An empty
    str_view or NULL pointer is valid and will return '\0'. */
-char sv_front(str_view);
+char sv_front(str_view sv);
 
 /* The character at the last position of str_view. An empty
    str_view or NULL pointer is valid and will return '\0'. */
-char sv_back(str_view);
+char sv_back(str_view sv);
 
 /*============================  Searching  =================================*/
 
@@ -339,23 +339,23 @@ str_view sv_rsvsv(str_view hay, str_view needle);
 
 /* Returns true if a prefix shorter than or equal in length to
    the str_view is present, false otherwise. */
-bool sv_starts_with(str_view, str_view prefix);
+bool sv_starts_with(str_view sv, str_view prefix);
 
 /* Removes the minimum between str_view length and n from the start
    of the str_view. It is safe to provide n larger than str_view
    size as that will result in a size 0 view to the end of the
    current view which may or may not be the null terminator. */
-str_view sv_remove_prefix(str_view, size_t n);
+str_view sv_remove_prefix(str_view sv, size_t n);
 
 /* Returns true if a suffix less or equal in length to str_view is
    present, false otherwise. */
-bool sv_ends_with(str_view, str_view suffix);
+bool sv_ends_with(str_view sv, str_view suffix);
 
 /* Removes the minimum between str_view length and n from the end. It
    is safe to provide n larger than str_view and that will result in
    a size 0 view to the end of the current view which may or may not
    be the null terminator. */
-str_view sv_remove_suffix(str_view, size_t n);
+str_view sv_remove_suffix(str_view sv, size_t n);
 
 /* Finds the first position of an occurence of any character in set.
    If no occurence is found hay size is returned. An empty set (NULL)
@@ -382,6 +382,6 @@ size_t sv_find_last_not_of(str_view hay, str_view set);
 /*============================  Printing  ==================================*/
 
 /* Writes all characters in str_view to specified file such as stdout. */
-void sv_print(FILE *, str_view);
+void sv_print(FILE *f, str_view sv);
 
 #endif /* STR_VIEW */

--- a/str_view/str_view.h
+++ b/str_view/str_view.h
@@ -31,7 +31,7 @@ typedef enum
 /*==========================  Construction  ================================*/
 
 /* A macro provided to obtain the length of string literals. Best used with
-   the next macro but perhaps has uses on its own.
+   the macro below, but perhaps has uses on its own.
 
       static const str_view prefix = {.s = "test_", .sz = SVLEN("test_")};
 
@@ -39,7 +39,7 @@ typedef enum
 #define SVLEN(str) ((sizeof((str)) / sizeof((str)[0])) - sizeof((str)[0]))
 
 /* A macro to reduce the chance for errors in repeating oneself when
-   constructing inline or const str_views. The input must be a string
+   constructing an inline or const str_view. The input must be a string
    literal. For example, the above example becomes:
 
       static const str_view prefix = SV("test_");
@@ -67,24 +67,15 @@ str_view sv_n(const char *str, size_t n);
 /* Constructs and returns a string view from a NULL TERMINATED string
    broken on the first ocurrence of delimeter if found or null
    terminator if delim cannot be found. This constructor will also
-   skip the delimeter if that delimeter starts the string. For example:
-
-     const char *const str = "  Hello world!";
-     sv_print(sv_delim(str, " "));
-     <<< "Hello"
-
-   Or the string may be empty if it is made of delims.
-
-     const char *const str = "------";
-     sv_print(sv_delim(str, "-"));
-     <<< ""
-
-   This is similar to the tokenizing function in the iterator section. */
+   skip the delimeter if that delimeter starts the string. This is similar
+   to the tokenizing function in the iteration section. */
 str_view sv_delim(const char *str, const char *delim);
 
 /* Creates the substring from position pos for count length. The count is
-   the minimum value between count and (str_view.sz - pos). The process
-   will exit if position is greater than str_view size. */
+   the minimum value between count and (str_view.sz - pos). If an invalid
+   position is given greater than str_view length an empty view is returned
+   positioned at the end of str_view. This position may or may not hold the
+   null terminator. */
 str_view sv_substr(str_view sv, size_t pos, size_t count);
 
 /* A sentinel empty string. Safely dereferenced to view a null terminator.

--- a/tests/run_tests.c
+++ b/tests/run_tests.c
@@ -149,11 +149,13 @@ static bool
 fill_path(char *path_buf, str_view tests_dir, str_view entry)
 {
     const size_t dir_bytes = sv_fill(path_buf, FILESYS_MAX_PATH, tests_dir);
-    if (FILESYS_MAX_PATH - dir_bytes < sv_svbytes(entry))
+    if (FILESYS_MAX_PATH - dir_bytes < sv_bytes(entry))
     {
-        (void)fprintf(stderr, "Relative path exceeds FILESYS_MAX_PATH?\n%s", path_buf);
+        (void)fprintf(stderr, "Relative path exceeds FILESYS_MAX_PATH?\n%s",
+                      path_buf);
         return false;
     }
-    (void)sv_fill(path_buf + sv_len(tests_dir), FILESYS_MAX_PATH - dir_bytes, entry);
+    (void)sv_fill(path_buf + sv_len(tests_dir), FILESYS_MAX_PATH - dir_bytes,
+                  entry);
     return true;
 }

--- a/tests/test_comparisons.c
+++ b/tests/test_comparisons.c
@@ -58,9 +58,9 @@ test_compare_single(void)
     const int cmp_res = strcmp(e1, e2);
     const int cmp_res2 = strcmp(e2, e1);
     CHECK(cmp_res < 0, sv_strcmp(e1_view, e2) < 0);
-    CHECK(cmp_res < 0, sv_svcmp(e1_view, e2_view) < 0);
+    CHECK(cmp_res < 0, sv_cmp(e1_view, e2_view) < 0);
     CHECK(cmp_res2 > 0, sv_strcmp(e2_view, e1) > 0);
-    CHECK(cmp_res2 > 0, sv_svcmp(e2_view, e1_view) > 0);
+    CHECK(cmp_res2 > 0, sv_cmp(e2_view, e1_view) > 0);
     return PASS;
 }
 
@@ -78,9 +78,9 @@ test_compare_equal(void)
     const int cmp_res = strcmp(e1, e2);
     const int cmp_res2 = strcmp(e2, e1);
     CHECK(cmp_res, sv_strcmp(e1_view, e2));
-    CHECK(cmp_res, sv_svcmp(e1_view, e2_view));
+    CHECK(cmp_res, sv_cmp(e1_view, e2_view));
     CHECK(cmp_res2, sv_strcmp(e2_view, e1));
-    CHECK(cmp_res2, sv_svcmp(e2_view, e1_view));
+    CHECK(cmp_res2, sv_cmp(e2_view, e1_view));
     return PASS;
 }
 
@@ -97,9 +97,9 @@ test_compare_equal_view(void)
     const str_view e1_view = sv(e1);
     const str_view e2_view = sv_n(e2, sv_strlen(e1));
     const int cmp_res = strcmp(e1, e1);
-    CHECK(cmp_res, sv_svcmp(e1_view, e2_view));
+    CHECK(cmp_res, sv_cmp(e1_view, e2_view));
     CHECK(cmp_res, sv_strcmp(e2_view, e1));
-    CHECK(cmp_res, sv_svcmp(e2_view, e1_view));
+    CHECK(cmp_res, sv_cmp(e2_view, e1_view));
     return PASS;
 }
 
@@ -117,9 +117,9 @@ test_compare_terminated(void)
     const int cmp_res = strcmp(lesser, greater);
     const int cmp_res2 = strcmp(greater, lesser);
     CHECK(cmp_res < 0, sv_strcmp(lesser_view, greater) < 0);
-    CHECK(cmp_res < 0, sv_svcmp(lesser_view, greater_view) < 0);
+    CHECK(cmp_res < 0, sv_cmp(lesser_view, greater_view) < 0);
     CHECK(cmp_res2 > 0, sv_strcmp(greater_view, lesser) > 0);
-    CHECK(cmp_res2 > 0, sv_svcmp(greater_view, lesser_view) > 0);
+    CHECK(cmp_res2 > 0, sv_cmp(greater_view, lesser_view) > 0);
     return PASS;
 }
 
@@ -134,9 +134,9 @@ test_compare_different_lengths_terminated(void)
     const int cmp_res = strcmp(lesser, greater);
     const int cmp_res2 = strcmp(greater, lesser);
     CHECK(cmp_res < 0, sv_strcmp(less_view, greater) < 0);
-    CHECK(cmp_res < 0, sv_svcmp(less_view, greater_view) < 0);
+    CHECK(cmp_res < 0, sv_cmp(less_view, greater_view) < 0);
     CHECK(cmp_res2 > 0, sv_strcmp(greater_view, lesser) > 0);
-    CHECK(cmp_res2 > 0, sv_svcmp(greater_view, less_view) > 0);
+    CHECK(cmp_res2 > 0, sv_cmp(greater_view, less_view) > 0);
     return PASS;
 }
 
@@ -160,24 +160,24 @@ test_compare_different_lengths_views(void)
     const str_view lesser_view = sv(lesser);
     CHECK(str_cmp2 > 0, sv_strcmp(greater_view, lesser) > 0);
     CHECK(str_cmp < 0, sv_strcmp(lesser_view, greater_str) < 0);
-    CHECK(str_cmp < 0, sv_svcmp(lesser_view, greater_view) < 0);
-    CHECK(str_cmp2 > 0, sv_svcmp(greater_view, lesser_view) > 0);
+    CHECK(str_cmp < 0, sv_cmp(lesser_view, greater_view) < 0);
+    CHECK(str_cmp2 > 0, sv_cmp(greater_view, lesser_view) > 0);
     return PASS;
 }
 
 static enum test_result
 test_compare_misc(void)
 {
-    CHECK(sv_svcmp(sv(""), sv("")), EQL);
+    CHECK(sv_cmp(sv(""), sv("")), EQL);
     CHECK(sv_strcmp(sv(""), ""), EQL);
-    CHECK(sv_svcmp(sv("same"), sv("same")), EQL);
-    CHECK(sv_svcmp(sv("samz"), sv("same")), GRT);
-    CHECK(sv_svcmp(sv("same"), sv("samz")), LES);
+    CHECK(sv_cmp(sv("same"), sv("same")), EQL);
+    CHECK(sv_cmp(sv("samz"), sv("same")), GRT);
+    CHECK(sv_cmp(sv("same"), sv("samz")), LES);
     /* The comparison function should treat the end of a string view as
        null terminating character even if it points to a delimeter */
-    CHECK(sv_svcmp(sv("same"), sv_delim("same same", " ")), EQL);
-    CHECK(sv_svcmp(sv("same"), sv_delim("samz same", " ")), LES);
-    CHECK(sv_svcmp(sv_delim("sameez same", " "), sv("same")), GRT);
+    CHECK(sv_cmp(sv("same"), sv_delim("same same", " ")), EQL);
+    CHECK(sv_cmp(sv("same"), sv_delim("samz same", " ")), LES);
+    CHECK(sv_cmp(sv_delim("sameez same", " "), sv("same")), GRT);
     const char *const str = "same";
     CHECK(sv_strcmp(sv(str), str), EQL);
     CHECK(sv_strcmp(sv_delim("same same", " "), str), EQL);

--- a/tests/test_copy_fill.c
+++ b/tests/test_copy_fill.c
@@ -55,8 +55,8 @@ test_copy_section(void)
     const char *const expected_snip = "snip!";
     const str_view ref_view = sv(ref);
     const str_view snip = sv_substr(ref_view, 5, 5);
-    char snip_buf[sv_svbytes(snip)];
-    CHECK(sv_fill(snip_buf, sizeof snip_buf, snip), sv_svbytes(snip));
+    char snip_buf[sv_bytes(snip)];
+    CHECK(sv_fill(snip_buf, sizeof snip_buf, snip), sv_bytes(snip));
     CHECK(strcmp(expected_snip, snip_buf), 0);
     CHECK(snip_buf[(sizeof snip_buf) - 1], '\0');
     return PASS;

--- a/tests/test_iterators.c
+++ b/tests/test_iterators.c
@@ -170,7 +170,7 @@ test_riter(void)
     str_view cur2 = sv_rbegin_tok(ref, sv(","));
     for (; !sv_rend_tok(ref, cur2); cur2 = sv_rnext_tok(ref, cur2, sv(",")))
     {
-        CHECK(sv_svcmp(cur2, ref), EQL);
+        CHECK(sv_cmp(cur2, ref), EQL);
     }
     CHECK(cur2.s, ref.s);
     return PASS;
@@ -209,7 +209,7 @@ test_riter2(void)
          cur2 = sv_rnext_tok(ref, cur2, sv(",")))
     {
         --i;
-        CHECK(sv_svcmp(cur2, ref), EQL);
+        CHECK(sv_cmp(cur2, ref), EQL);
         CHECK(sv_len(cur2), sv_len(ref));
     }
     CHECK(cur2.s, ref.s);
@@ -243,7 +243,7 @@ test_riter_multi(void)
          cur2 = sv_rnext_tok(ref, cur2, SV(",")))
     {
         --i;
-        CHECK(sv_svcmp(cur2, ref), EQL);
+        CHECK(sv_cmp(cur2, ref), EQL);
         CHECK(sv_len(cur2), sv_len(ref));
     }
     CHECK(cur2.s, ref.s);
@@ -259,14 +259,14 @@ test_min_delim(void)
     str_view i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0/");
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -274,7 +274,7 @@ test_min_delim(void)
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -284,7 +284,7 @@ test_min_delim(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -295,7 +295,7 @@ test_min_delim(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -306,7 +306,7 @@ test_min_delim(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -317,7 +317,7 @@ test_min_delim(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -334,14 +334,14 @@ test_min_delim_two_byte(void)
     str_view i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0//");
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -349,7 +349,7 @@ test_min_delim_two_byte(void)
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -359,7 +359,7 @@ test_min_delim_two_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -370,7 +370,7 @@ test_min_delim_two_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -381,7 +381,7 @@ test_min_delim_two_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -392,7 +392,7 @@ test_min_delim_two_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -409,14 +409,14 @@ test_min_delim_three_byte(void)
     str_view i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0///");
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -424,7 +424,7 @@ test_min_delim_three_byte(void)
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -434,7 +434,7 @@ test_min_delim_three_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -445,7 +445,7 @@ test_min_delim_three_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -456,7 +456,7 @@ test_min_delim_three_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -467,7 +467,7 @@ test_min_delim_three_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -484,14 +484,14 @@ test_min_delim_four_byte(void)
     str_view i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0////");
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -499,7 +499,7 @@ test_min_delim_four_byte(void)
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -509,7 +509,7 @@ test_min_delim_four_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -520,7 +520,7 @@ test_min_delim_four_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -531,7 +531,7 @@ test_min_delim_four_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -542,7 +542,7 @@ test_min_delim_four_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -559,14 +559,14 @@ test_min_delim_five_byte(void)
     str_view i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0/////");
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -574,7 +574,7 @@ test_min_delim_five_byte(void)
     i = sv_begin_tok(ref, delim);
     for (; !sv_end_tok(ref, i); i = sv_next_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -584,7 +584,7 @@ test_min_delim_five_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -595,7 +595,7 @@ test_min_delim_five_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -606,7 +606,7 @@ test_min_delim_five_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -617,7 +617,7 @@ test_min_delim_five_byte(void)
     for (; !sv_end_tok(ref, i) && sz; i = sv_next_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s + ref.sz);
@@ -634,14 +634,14 @@ test_rmin_delim(void)
     str_view i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0/");
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -649,7 +649,7 @@ test_rmin_delim(void)
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -659,7 +659,7 @@ test_rmin_delim(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -670,7 +670,7 @@ test_rmin_delim(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -681,7 +681,7 @@ test_rmin_delim(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -692,7 +692,7 @@ test_rmin_delim(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -709,14 +709,14 @@ test_rmin_delim_two_byte(void)
     str_view i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0//");
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -724,7 +724,7 @@ test_rmin_delim_two_byte(void)
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -734,7 +734,7 @@ test_rmin_delim_two_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -745,7 +745,7 @@ test_rmin_delim_two_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -756,7 +756,7 @@ test_rmin_delim_two_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -767,7 +767,7 @@ test_rmin_delim_two_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -784,14 +784,14 @@ test_rmin_delim_three_byte(void)
     str_view i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0///");
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -799,7 +799,7 @@ test_rmin_delim_three_byte(void)
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -809,7 +809,7 @@ test_rmin_delim_three_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -820,7 +820,7 @@ test_rmin_delim_three_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -831,7 +831,7 @@ test_rmin_delim_three_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -842,7 +842,7 @@ test_rmin_delim_three_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -859,14 +859,14 @@ test_rmin_delim_four_byte(void)
     str_view i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0////");
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -874,7 +874,7 @@ test_rmin_delim_four_byte(void)
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -884,7 +884,7 @@ test_rmin_delim_four_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -895,7 +895,7 @@ test_rmin_delim_four_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -906,7 +906,7 @@ test_rmin_delim_four_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -917,7 +917,7 @@ test_rmin_delim_four_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -934,14 +934,14 @@ test_rmin_delim_five_byte(void)
     str_view i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     ref = SV("0/////");
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -949,7 +949,7 @@ test_rmin_delim_five_byte(void)
     i = sv_rbegin_tok(ref, delim);
     for (; !sv_rend_tok(ref, i); i = sv_rnext_tok(ref, i, delim))
     {
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -959,7 +959,7 @@ test_rmin_delim_five_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -970,7 +970,7 @@ test_rmin_delim_five_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -981,7 +981,7 @@ test_rmin_delim_five_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -992,7 +992,7 @@ test_rmin_delim_five_byte(void)
     for (; !sv_rend_tok(ref, i) && sz; i = sv_rnext_tok(ref, i, delim))
     {
         --sz;
-        CHECK(sv_svcmp(i, tok), EQL);
+        CHECK(sv_cmp(i, tok), EQL);
         CHECK(sv_len(i), sv_len(tok));
     }
     CHECK(i.s, ref.s);
@@ -1311,7 +1311,7 @@ test_iter_delim_larger_than_str(void)
     str_view constructed = sv_delim(reference, delim.s);
     str_view cur
         = sv_begin_tok((str_view){reference, sv_strlen(reference)}, delim);
-    CHECK(sv_svcmp(constructed, cur), EQL);
+    CHECK(sv_cmp(constructed, cur), EQL);
     CHECK(sv_strcmp(constructed, reference), EQL);
     CHECK(sv_strcmp(cur, reference), EQL);
 
@@ -1334,14 +1334,14 @@ test_riter_delim_larger_than_str(void)
     str_view constructed = sv_delim(reference, delim.s);
     str_view cur
         = sv_rbegin_tok((str_view){reference, sv_strlen(reference)}, delim);
-    CHECK(sv_svcmp(constructed, cur), EQL);
+    CHECK(sv_cmp(constructed, cur), EQL);
     CHECK(sv_strcmp(constructed, reference), EQL);
     CHECK(sv_strcmp(cur, reference), EQL);
 
     for (; !sv_rend_tok(ref_view, cur);
          cur = sv_rnext_tok(ref_view, cur, delim))
     {
-        CHECK(sv_svcmp(cur, ref_view), EQL);
+        CHECK(sv_cmp(cur, ref_view), EQL);
         CHECK(sv_len(cur), sv_len(ref_view));
     }
     CHECK(*cur.s, *reference);

--- a/tests/test_length_vs_bytes.c
+++ b/tests/test_length_vs_bytes.c
@@ -43,7 +43,7 @@ test_length_terminated(void)
     CHECK(len, sv_strlen(ref));
     CHECK(len, sv_len(sv(ref)));
     CHECK(bytes, sv_strbytes(ref));
-    CHECK(bytes, sv_svbytes(sv(ref)));
+    CHECK(bytes, sv_bytes(sv(ref)));
     CHECK(len, sv_npos(sv(ref)));
     CHECK(len, sv_minlen(ref, -1));
     return PASS;
@@ -63,7 +63,7 @@ test_length_unterminated(void)
     CHECK(sv_strlen(snip), len);
     CHECK(sv_len(snip_view), len);
     CHECK(sv_strbytes(snip), bytes);
-    CHECK(sv_svbytes(snip_view), bytes);
+    CHECK(sv_bytes(snip_view), bytes);
     CHECK(len, sv_npos(snip_view));
     CHECK(len, sv_minlen(snip, 99));
     return PASS;
@@ -83,14 +83,14 @@ test_length_innacurate(void)
     CHECK(len, sv_strlen(ref));
     CHECK(len, sv_len(view));
     CHECK(bytes, sv_strbytes(ref));
-    CHECK(bytes, sv_svbytes(view));
+    CHECK(bytes, sv_bytes(view));
     CHECK(len, sv_npos(view));
     CHECK(len, sv_minlen(ref, 99));
     const str_view view2 = sv_n(ref, -1);
     CHECK(len, sv_strlen(ref));
     CHECK(len, sv_len(view2));
     CHECK(bytes, sv_strbytes(ref));
-    CHECK(bytes, sv_svbytes(view2));
+    CHECK(bytes, sv_bytes(view2));
     CHECK(len, (sv_npos(view2)));
     CHECK(len, sv_minlen(ref, 99));
     return PASS;

--- a/tests/test_out_of_bounds.c
+++ b/tests/test_out_of_bounds.c
@@ -1,34 +1,15 @@
 #include "str_view.h"
 #include "test.h"
 
-#include <fcntl.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
 int
 main()
 {
-    const str_view s = sv("");
-    const pid_t exiting_child = fork();
-    if (exiting_child == 0)
-    {
-        /* Silence the str_view message that is about to output at exit. */
-        int silence = open("/dev/null", O_WRONLY);
-        dup2(silence, STDERR_FILENO);
-        (void)sv_at(s, 1);
-        /* We should not make it here */
-        exit(ERROR);
-    }
-    int status = 0;
-    if (waitpid(exiting_child, &status, 0) < 0)
-    {
-        printf("Error waiting for failing child.\n");
-        exit(1);
-    }
-    /* We expect to have exited with a status of 1 */
-    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 1, true);
+    const str_view s = sv("a");
+    const str_view empty = (str_view){s.s + 1, 0};
+    CHECK(sv_at(s, 9), '\0');
+    CHECK(sv_pos(s, 9), s.s + 1);
+    const str_view sub_s = sv_substr(s, 9, 9);
+    CHECK(sub_s.s, empty.s);
+    CHECK(sub_s.sz, empty.sz);
     return PASS;
 }

--- a/tests/test_string_searching.c
+++ b/tests/test_string_searching.c
@@ -344,7 +344,7 @@ test_substring_search(void)
     str_view b = sv_n(a, needle_len);
     str_view c = sv_svsv(haystack_view, needle_view);
 
-    CHECK(sv_svcmp(b, c), EQL);
+    CHECK(sv_cmp(b, c), EQL);
     CHECK(c.s, a);
     a += needle_len;
     a = strstr(a, needle);
@@ -356,7 +356,7 @@ test_substring_search(void)
     const str_view new_haystack_view = sv(a);
     b = sv_n(a, needle_len);
     c = sv_svsv(new_haystack_view, needle_view);
-    CHECK(sv_svcmp(b, c), EQL);
+    CHECK(sv_cmp(b, c), EQL);
     CHECK(c.s, a);
     const str_view first_chunk
         = sv_substr(haystack_view, 0, sv_find(haystack_view, 0, needle_view));
@@ -372,11 +372,11 @@ test_substring_search(void)
     {
         if (i == 0)
         {
-            CHECK(sv_svcmp(v, first_chunk), EQL);
+            CHECK(sv_cmp(v, first_chunk), EQL);
         }
         else
         {
-            CHECK(sv_svcmp(v, second_chunk), EQL);
+            CHECK(sv_cmp(v, second_chunk), EQL);
         }
         ++i;
     }
@@ -408,14 +408,14 @@ test_rsubstring_search(void)
     const str_view middle_needle = sv_rsvsv(haystack_view, needle_view);
     const size_t middle_pos
         = sv_rfind(haystack_view, haystack_view.sz, needle_view);
-    CHECK(sv_svcmp(middle_needle, needle_view), EQL);
+    CHECK(sv_cmp(middle_needle, needle_view), EQL);
     CHECK(middle_needle.s, middle);
     CHECK(middle_pos, (size_t)(middle - haystack));
     const str_view first_chunk_view = sv_n(haystack, middle_pos);
     const str_view begin_needle = sv_rsvsv(first_chunk_view, needle_view);
     const size_t begin_pos
         = sv_rfind(first_chunk_view, first_chunk_view.sz, needle_view);
-    CHECK(sv_svcmp(begin_needle, needle_view), EQL);
+    CHECK(sv_cmp(begin_needle, needle_view), EQL);
     CHECK(begin_needle.s, begin);
     CHECK(begin_pos, (size_t)(begin - haystack));
     return PASS;
@@ -445,6 +445,6 @@ test_long_substring(void)
         = sv_rfind(haystack_view, sv_len(haystack_view), needle_view);
     CHECK(rfind_pos, (size_t)(strstr_needle - haystack));
 
-    CHECK(sv_svcmp(svsv_needle, rsvsv_needle), EQL);
+    CHECK(sv_cmp(svsv_needle, rsvsv_needle), EQL);
     return PASS;
 }

--- a/tests/test_view_editing.c
+++ b/tests/test_view_editing.c
@@ -107,7 +107,7 @@ test_dir_entries(void)
         = sv_substr(root_single_entry_slash, 0,
                     sv_rfind(root_single_entry_slash,
                              sv_len(root_single_entry_slash), dirslash));
-    CHECK(sv_svcmp(without_last_slash, root_single_entry), EQL);
+    CHECK(sv_cmp(without_last_slash, root_single_entry), EQL);
     const str_view special_file = {"/this/is/a/very/special/file",
                                    SVLEN("/this/is/a/very/special/file")};
     const char *const toks[6] = {"this", "is", "a", "very", "special", "file"};


### PR DESCRIPTION
The internal implementation should not rewrite unneeded functionality that comes with most C implementations, only the functionality that actually needs to be different. The API names should be as consistent and short as possible. The str_view is assumed to be the default type being worked with. The str abbreviation can be used when needed. Finally, a library such as this should not exit. It should provide meaningful empty, error, or default values when something unexpected happens. The user can then act based on returned values that will not cause harm.